### PR TITLE
[WIP] Panelist sign-up and panel submission forms

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Annalee Flower Horne
+Copyright (c) 2019 Annalee Flower Horne, John Winkelman
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/alienplanit/settings.py
+++ b/alienplanit/settings.py
@@ -37,6 +37,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'bootstrap4',
     'scheduler.apps.SchedulerConfig',
     'submissions.apps.SubmissionsConfig',
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 Django==2.2
+django-bootstrap4==0.0.8
+
+# Prod
 pytz==2018.7
 python-dotenv

--- a/submissions/forms.py
+++ b/submissions/forms.py
@@ -17,5 +17,5 @@ class PanelSubmissionForm(forms.Form):
         label='Notes for ConFusion Planners',
         widget=forms.Textarea,
         required=False,
-        help_text="Do you have specific panelists in mind? Require a/v? \
-                   Any other notes for us?")
+        help_text="Do you have specific panelists in mind? Require a/v? Any other notes for us?"
+        )

--- a/submissions/templates/submissions/panel.html
+++ b/submissions/templates/submissions/panel.html
@@ -1,17 +1,22 @@
 {% extends 'base.html' %}
+{% load bootstrap4 %}
 
 {% block head %}
 <!-- I'm rendered in alienplanit/submissions/templates/submissions/panel.html 
-	If you need to add more items to <head> for this page only, here is where you do it!-->
+    If you need to add more items to <head> for this page only, here is where you do it!-->
 {% endblock head %}
 
 {% block main %}
 <!-- I'm rendered in alienplanit/submissions/templates/submissions/panel.html 
-	This is where to make changes to the main block for this page only.-->
+    This is where to make changes to the main block for this page only.-->
 <div>{{ declaration }}</div>
 <form action="{% url 'panel' %}" method="post">
     {% csrf_token %}
-    {{ panelform }}
-    <input type="submit" value="Submit">
+    {% bootstrap_form panelform %}
+    {% buttons %}
+        <button type="submit" class="btn btn-primary">
+            Submit
+        </button>
+    {% endbuttons %}
 </form>
 {% endblock main %}

--- a/submissions/templates/submissions/panelist.html
+++ b/submissions/templates/submissions/panelist.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% load bootstrap4 %}
 
 {% block head %}
 <!-- I'm rendered in alienplanit/submissions/templates/submissions/panelist.html 
@@ -9,7 +10,11 @@
 <div>{{ declaration }}</div>
 <form action="{% url 'panelist' %}" method="post">
     {% csrf_token %}
-    {{ panelistform }}
-    <input type="submit" value="Submit">
+    {% bootstrap_form panelistform %}
+    {% buttons %}
+    <button type="submit" class="btn btn-primary">
+      Submit
+    </button>
+    {% endbuttons %}
 </form>
 {% endblock main %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,8 +1,21 @@
 {% load static %}
 
+{# importing django-bootstrap4 #}
+{% load bootstrap4 %}
+
+{% bootstrap_css %}
+{% bootstrap_javascript jquery='full' %}
+
+{# Display django.contrib.messages as Bootstrap alerts #}
+{% bootstrap_messages %}
+
+
 <html>
     <head>
     <!--I'm rendered in alienplanit/templates/base.html . Sitewide head content goes here.-->
+    {% bootstrap_css %}
+    {% bootstrap_javascript jquery='full' %}
+
     {% block head %}
     <!--this block can be overwritten by individual templates to add more items to <head>. -->
     {% endblock %}


### PR DESCRIPTION
Resolves #14 and #12.

The back-end work to wire up these forms has already been merged into `Master` because I wasn't using particularly good branch hygiene, but the second-best time to do things right is now.

New in this branch:
- creates a top-level static files directory with a css subdirectory 
- installed django-bootstrap4
- added bootstrap tags to both the `/submissions/panelist/` and `/submissions/panel/` pages

[Here are the docs for django-bootstrap4](https://django-bootstrap4.readthedocs.io/en/latest/).

**This branch includes changes to requirements.txt** so be sure to install the new requirements before running this branch.
